### PR TITLE
make h5 to json compatible with tart2ms json import

### DIFF
--- a/tart_tools/bin/tart_vis2json
+++ b/tart_tools/bin/tart_vis2json
@@ -11,13 +11,18 @@ import json
 
 def create_direct_vis_dict(vis):
     """ This function is provided with a visibility object. It returns a dictionary identical to the json response. """
-    vis_list = []
-    for (b, v) in zip(vis.baselines, vis.v):
-        i, j = b
-        vis_el = {"i": i, "j": j, "re": v.real, "im": v.imag}
-        vis_list.append(vis_el)
-    vis_dict = {"data": vis_list, "timestamp": vis.timestamp.isoformat()[:-3] + "Z"}
-    return vis_dict
+    vis_dicts = []
+    for visobj in vis["vis_list"]:
+        vis_list = []
+        timestamp = visobj.timestamp.isoformat()[:-3] + "Z"
+        for b, v in zip(visobj.baselines, visobj.v):
+            i, j = b
+            vis_el = {"i": i, "j": j, "re": v.real, "im": v.imag}
+            vis_list.append(vis_el)
+        vis_dicts.append({"data": [({"data": vis_list, "timestamp": timestamp},
+                                    [])], 
+                          "timestamp": timestamp})
+    return vis_dicts
 
 
 if __name__ == "__main__":
@@ -28,14 +33,23 @@ if __name__ == "__main__":
         "--vis", required=False, nargs="*", default="", help="Visibilities data file."
     )
     ARGS = PARSER.parse_args()
-
+    VIS_LIST = []
     if len(ARGS.vis) != 0:
-        VIS_LIST = []
         for vis_file in ARGS.vis:
-            VIS_LIST += visibility.list_load(vis_file)
+            VIS_LIST.append(visibility.list_load(vis_file))
 
     for vis in VIS_LIST:
-        vis_dict = create_direct_vis_dict(vis)
-        fname = "vis_" + vis_dict["timestamp"] + ".json"
-        with open(fname, "w") as fp:
-            json.dump(vis_dict, fp)
+        dico_info = {"info": json.loads(vis['config'].to_json())}
+        dico_info["info"]['operating_frequency'] = dico_info["info"]['frequency']
+        dico_info["info"]['location'] = {"lat": dico_info["info"]["lat"],
+                                         "lon": dico_info["info"]["lon"],
+                                         "alt": dico_info["info"]["alt"]}
+        vis_dicts = create_direct_vis_dict(vis)
+        for vis_dict in vis_dicts:
+            vis_dict["info"] = dico_info
+            vis_dict["ant_pos"] = vis["ant_pos"].tolist()
+            vis_dict["gains"] = {"gain": vis["gain"].tolist(),
+                                 "phase_offset": vis["phase_offset"].tolist()}
+            fname = "vis_" + vis_dict["timestamp"] + ".json"
+            with open(fname, "w") as fp:
+                json.dump(vis_dict, fp)


### PR DESCRIPTION
@tmolteno this is by trial and error. It seems to be importing into tart2ms but required a lot of muckery to get your json structure adequitely reproduced. I can't find sources anywhere but I guess h5 don't store them.... please review and build upon this if I missed anything. This now exports a dict per timestamp of the h5